### PR TITLE
[add] paragraph에 있는 ref 제거 및 미주 각주 제거

### DIFF
--- a/src/main/java/choiKoDaKimNamChung/grammarChecker/docx/EndNote.java
+++ b/src/main/java/choiKoDaKimNamChung/grammarChecker/docx/EndNote.java
@@ -1,0 +1,18 @@
+package choiKoDaKimNamChung.grammarChecker.docx;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+public class EndNote extends IBody{
+    int num;
+    List<IBody> content;
+    public EndNote(int num) {
+        super(IBodyType.END_NOTE);
+        this.num = num;
+    }
+}
+

--- a/src/main/java/choiKoDaKimNamChung/grammarChecker/docx/FootNote.java
+++ b/src/main/java/choiKoDaKimNamChung/grammarChecker/docx/FootNote.java
@@ -1,0 +1,18 @@
+package choiKoDaKimNamChung.grammarChecker.docx;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+public class FootNote extends IBody{
+    int num;
+    List<IBody> content;
+    public FootNote(int num) {
+        super(IBodyType.FOOT_NOTE);
+        this.num = num;
+    }
+}
+


### PR DESCRIPTION
정용 학우의 코드 시험이 가능하게 일단 paragraph.getText()를 했을 때 나오는 ref와 끝에 미주, 각주를 없앴습니다.