### PR TITLE
2차 MVP(편집거리) 구현

### DIFF
--- a/src/main/java/choiKoDaKimNamChung/grammarChecker/service/docx/DocxApply.java
+++ b/src/main/java/choiKoDaKimNamChung/grammarChecker/service/docx/DocxApply.java
@@ -13,8 +13,6 @@ public interface DocxApply {
 
     public void tableParse(XWPFTable table, Table t);
 
-    public void paragraphParse(XWPFParagraph paragraph, Paragraph p);
-
 //    public String footNoteEndNoteIgnore(String paragraph); 라이브러리를 직접 수정하는 것을 고려
 
     public void endNoteFootNoteParse(XWPFAbstractFootnoteEndnote note, List<IBody> iBodyList);

--- a/src/main/java/choiKoDaKimNamChung/grammarChecker/service/docx/DocxApplyImp.java
+++ b/src/main/java/choiKoDaKimNamChung/grammarChecker/service/docx/DocxApplyImp.java
@@ -1,12 +1,20 @@
 package choiKoDaKimNamChung.grammarChecker.service.docx;
 
 import choiKoDaKimNamChung.grammarChecker.docx.*;
+
 import choiKoDaKimNamChung.grammarChecker.docx.IBody;
+import choiKoDaKimNamChung.grammarChecker.response.WordError;
+import lombok.RequiredArgsConstructor;
 import org.apache.poi.xwpf.usermodel.*;
+import org.springframework.stereotype.Service;
 
 import java.util.*;
 
+@Service
+@RequiredArgsConstructor
 public class DocxApplyImp implements DocxApply{
+
+    private final ParagraphApply paragraphApply;
     @Override
     public XWPFDocument docxParse(XWPFDocument document, Docx docx) {
         //header
@@ -21,7 +29,7 @@ public class DocxApplyImp implements DocxApply{
     @Override
     public void iBodyParse(IBodyElement bodyElement, IBody iBody) {
         if (iBody.getType() == IBodyType.PARAGRAPH){
-            paragraphParse((XWPFParagraph) bodyElement,(Paragraph) iBody);
+            paragraphApply.paragraphParse((XWPFParagraph) bodyElement,(Paragraph) iBody);
         }else if(iBody.getType() == IBodyType.TABLE){
             tableParse((XWPFTable) bodyElement,(Table) iBody);
         }else{
@@ -44,11 +52,6 @@ public class DocxApplyImp implements DocxApply{
                 }
             }
         }
-    }
-
-    @Override
-    public void paragraphParse(XWPFParagraph paragraph, Paragraph p) {
-
     }
 
     @Override

--- a/src/main/java/choiKoDaKimNamChung/grammarChecker/service/docx/DocxParserImp.java
+++ b/src/main/java/choiKoDaKimNamChung/grammarChecker/service/docx/DocxParserImp.java
@@ -12,6 +12,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 

--- a/src/main/java/choiKoDaKimNamChung/grammarChecker/service/docx/EditDistanceParagraphApply.java
+++ b/src/main/java/choiKoDaKimNamChung/grammarChecker/service/docx/EditDistanceParagraphApply.java
@@ -1,0 +1,13 @@
+package choiKoDaKimNamChung.grammarChecker.service.docx;
+
+import choiKoDaKimNamChung.grammarChecker.docx.Paragraph;
+import org.apache.poi.xwpf.usermodel.XWPFParagraph;
+
+public class EditDistanceParagraphApply implements ParagraphApply{
+
+    @Override
+    public void paragraphParse(XWPFParagraph paragraph, Paragraph p) {
+        int runIdx = paragraph.getRuns().size() - 1;
+
+    }
+}

--- a/src/main/java/choiKoDaKimNamChung/grammarChecker/service/docx/EditDistanceParagraphApply.java
+++ b/src/main/java/choiKoDaKimNamChung/grammarChecker/service/docx/EditDistanceParagraphApply.java
@@ -1,21 +1,75 @@
 package choiKoDaKimNamChung.grammarChecker.service.docx;
 
 import choiKoDaKimNamChung.grammarChecker.docx.Paragraph;
+import choiKoDaKimNamChung.grammarChecker.response.WordError;
 import org.apache.poi.xwpf.usermodel.XWPFParagraph;
+import org.springframework.stereotype.Service;
 
 import java.util.LinkedList;
 import java.util.Queue;
 
+@Service
 public class EditDistanceParagraphApply implements ParagraphApply{
 
     @Override
     public void paragraphParse(XWPFParagraph paragraph, Paragraph p) {
         int runIdx = paragraph.getRuns().size() - 1;
+        int errorIdx = p.getErrors().size() - 1;
+        int charIdx = paragraph.getText().length();
 
+        while(errorIdx>=0){
+            if(p.getErrors().get(errorIdx).getReplaceStr() == null){
+                errorIdx--;
+                continue;
+            }
+            WordError error = p.getErrors().get(errorIdx--);
+            Queue<Edit> edits = trackingEditDistance(error.getOrgStr(), error.getReplaceStr());
+            while(charIdx - paragraph.getRuns().get(runIdx).text().length() > error.getEnd() - 1) {
+                charIdx -= paragraph.getRuns().get(runIdx).text().length();
+                runIdx--;
+            }
+
+            int runEditIndex = paragraph.getRuns().get(runIdx).text().length() - (charIdx - error.getEnd()) - 1;
+            int replaceEditIndex = error.getReplaceStr().length() - 1;
+            StringBuilder sb = new StringBuilder(paragraph.getRuns().get(runIdx).text());
+
+            for (Edit edit : edits) {
+                if(edit==Edit.CASCADE){
+                    sb.setCharAt(runEditIndex--, error.getReplaceStr().charAt(replaceEditIndex--));
+                } else if (edit == Edit.DELETE) {
+                    sb.deleteCharAt(runEditIndex--);
+                } else if(edit == Edit.ADD){
+                    sb.insert(runEditIndex + 1, error.getReplaceStr().charAt(replaceEditIndex--));
+                } else{
+                    runEditIndex--;
+                    replaceEditIndex--;
+                }
+
+                if(runEditIndex < 0 && runIdx != 0){
+                    paragraph.getRuns().get(runIdx).setText(sb.toString(),0);
+                    runEditIndex = paragraph.getRuns().get(--runIdx).text().length() - 1;
+                    sb = new StringBuilder(paragraph.getRuns().get(runIdx).text());
+                }
+            }
+            paragraph.getRuns().get(runIdx).setText(sb.toString(),0);
+        }
     }
 
+//
+//    protected String changeString(String str, Integer i, Edit edit, Character c){
+//        if(edit==Edit.CASCADE){
+//            return str.substring(0, i) + c.toString() + str.substring(i+1);
+//        }
+//        if(edit==Edit.DELETE){
+//            return str.substring(0, i) + str.substring(i+1);
+//        }
+//        if(edit==Edit.ADD){
+//            return str.substring(0, i) + c.toString() + str.substring(i);
+//        }
+//        return str;
+//    }
 
-    public Queue<Edit> trackingEditDistance(String origin, String replace) {
+    protected Queue<Edit> trackingEditDistance(String origin, String replace) {
         int m = origin.length();
         int n = replace.length();
 
@@ -78,13 +132,13 @@ public class EditDistanceParagraphApply implements ParagraphApply{
     //편집거리 테스트
     public static void main(String[] args) {
         EditDistanceParagraphApply edt = new EditDistanceParagraphApply();
-        Queue<Edit> result = edt.trackingEditDistance("안농하세요", "안녕하세요");
+        Queue<Edit> result = edt.trackingEditDistance("num20", "nUM 20");
         while (!result.isEmpty()) {
             System.out.println(result.poll());
         }
     }
 
-    private enum Edit {
+    protected enum Edit {
         ADD,KEEP,DELETE,CASCADE;
     }
 

--- a/src/main/java/choiKoDaKimNamChung/grammarChecker/service/docx/EditDistanceParagraphApply.java
+++ b/src/main/java/choiKoDaKimNamChung/grammarChecker/service/docx/EditDistanceParagraphApply.java
@@ -3,6 +3,9 @@ package choiKoDaKimNamChung.grammarChecker.service.docx;
 import choiKoDaKimNamChung.grammarChecker.docx.Paragraph;
 import org.apache.poi.xwpf.usermodel.XWPFParagraph;
 
+import java.util.LinkedList;
+import java.util.Queue;
+
 public class EditDistanceParagraphApply implements ParagraphApply{
 
     @Override
@@ -10,4 +13,79 @@ public class EditDistanceParagraphApply implements ParagraphApply{
         int runIdx = paragraph.getRuns().size() - 1;
 
     }
+
+
+    public Queue<Edit> trackingEditDistance(String origin, String replace) {
+        int m = origin.length();
+        int n = replace.length();
+
+        // dp 배열을 사용하여 최소 편집 횟수를 계산
+        int[][] dp = new int[m + 1][n + 1];
+
+        // 초기화
+        for (int i = 0; i <= m; i++) {
+            dp[i][0] = i;  // origin을 빈 문자열로 변경
+        }
+        for (int j = 0; j <= n; j++) {
+            dp[0][j] = j;  // 빈 문자열을 replace로 변경
+        }
+
+        // 편집 거리 계산
+        for (int i = 1; i <= m; i++) {
+            for (int j = 1; j <= n; j++) {
+                if (origin.charAt(i - 1) == replace.charAt(j - 1)) {
+                    dp[i][j] = dp[i - 1][j - 1];  // 문자가 같다면 변경 필요 없음
+                } else {
+                    dp[i][j] = 1 + Math.min(Math.min(dp[i - 1][j], dp[i][j - 1]), dp[i - 1][j - 1]);  // 삭제, 추가, 대체 중 최소 비용
+                }
+            }
+        }
+
+        // 최소 편집 경로 추적
+        Queue<Edit> edits = new LinkedList<>();
+        int i = m, j = n;
+        while (i > 0 && j > 0) {
+            if (origin.charAt(i - 1) == replace.charAt(j - 1)) {
+                edits.add(Edit.KEEP);
+                i--;
+                j--;
+            } else if (dp[i][j] == dp[i - 1][j - 1] + 1) {
+                edits.add(Edit.CASCADE);  // 대체
+                i--;
+                j--;
+            } else if (dp[i][j] == dp[i - 1][j] + 1) {
+                edits.add(Edit.DELETE);  // 삭제
+                i--;
+            } else if (dp[i][j] == dp[i][j - 1] + 1) {
+                edits.add(Edit.ADD);  // 추가
+                j--;
+            }
+        }
+
+        // 시작까지 도달
+        while (i > 0) {
+            edits.add(Edit.DELETE);
+            i--;
+        }
+        while (j > 0) {
+            edits.add(Edit.ADD);
+            j--;
+        }
+
+        return edits;
+    }
+
+    //편집거리 테스트
+    public static void main(String[] args) {
+        EditDistanceParagraphApply edt = new EditDistanceParagraphApply();
+        Queue<Edit> result = edt.trackingEditDistance("안농하세요", "안녕하세요");
+        while (!result.isEmpty()) {
+            System.out.println(result.poll());
+        }
+    }
+
+    private enum Edit {
+        ADD,KEEP,DELETE,CASCADE;
+    }
+
 }

--- a/src/main/java/choiKoDaKimNamChung/grammarChecker/service/docx/FirstCharParagraphApply.java
+++ b/src/main/java/choiKoDaKimNamChung/grammarChecker/service/docx/FirstCharParagraphApply.java
@@ -1,0 +1,52 @@
+package choiKoDaKimNamChung.grammarChecker.service.docx;
+
+import choiKoDaKimNamChung.grammarChecker.docx.Paragraph;
+import choiKoDaKimNamChung.grammarChecker.response.WordError;
+import org.apache.poi.xwpf.usermodel.XWPFParagraph;
+import org.springframework.stereotype.Service;
+
+@Service
+public class FirstCharParagraphApply implements ParagraphApply{
+
+    @Override
+    public void paragraphParse(XWPFParagraph paragraph, Paragraph p) {
+        int runIdx = paragraph.getRuns().size()-1;
+        int errorIdx = p.getErrors().size()-1;
+        int charIdx = paragraph.getText().length();
+        while(errorIdx>=0){
+            if(p.getErrors().get(errorIdx).getReplaceStr() == null){
+                errorIdx--;
+                continue;
+            }
+            while(charIdx - paragraph.getRuns().get(runIdx).text().length() > p.getErrors().get(errorIdx).getEnd() - 1) {
+                charIdx -= paragraph.getRuns().get(runIdx).text().length();
+                runIdx--;
+            }
+
+            if(charIdx - paragraph.getRuns().get(runIdx).text().length() > p.getErrors().get(errorIdx).getStart() && charIdx > p.getErrors().get(errorIdx).getEnd()){
+                int length = paragraph.getRuns().get(runIdx).text().length();
+                paragraph.getRuns().get(runIdx).setText(paragraph.getRuns().get(runIdx).text().substring(paragraph.getRuns().get(runIdx).text().length() - (charIdx - p.getErrors().get(errorIdx).getEnd())),0);
+                runIdx--;
+                charIdx -= length;
+            }
+            while(charIdx - paragraph.getRuns().get(runIdx).text().length() > p.getErrors().get(errorIdx).getStart()){
+                charIdx -= paragraph.getRuns().get(runIdx).text().length();
+                paragraph.getRuns().get(runIdx).setText("",0);
+                runIdx--;
+            }
+
+            String origin = paragraph.getRuns().get(runIdx).text();
+            WordError error = p.getErrors().get(errorIdx--);
+            String change;
+            if(error.getEnd() < charIdx){
+                change = origin.substring(0,origin.length() - (charIdx - error.getStart())) + error.getReplaceStr() + origin.substring(origin.length() - (charIdx - error.getEnd()));
+            }else{
+                change = origin.substring(0,origin.length() - (charIdx - error.getStart())) + error.getReplaceStr();
+            }
+            paragraph.getRuns().get(runIdx).setText(change,0);
+        }
+
+
+    }
+
+}

--- a/src/main/java/choiKoDaKimNamChung/grammarChecker/service/docx/FirstCharParagraphApply.java
+++ b/src/main/java/choiKoDaKimNamChung/grammarChecker/service/docx/FirstCharParagraphApply.java
@@ -5,7 +5,7 @@ import choiKoDaKimNamChung.grammarChecker.response.WordError;
 import org.apache.poi.xwpf.usermodel.XWPFParagraph;
 import org.springframework.stereotype.Service;
 
-@Service
+//@Service
 public class FirstCharParagraphApply implements ParagraphApply{
 
     @Override

--- a/src/main/java/choiKoDaKimNamChung/grammarChecker/service/docx/ParagraphApply.java
+++ b/src/main/java/choiKoDaKimNamChung/grammarChecker/service/docx/ParagraphApply.java
@@ -1,0 +1,8 @@
+package choiKoDaKimNamChung.grammarChecker.service.docx;
+
+import choiKoDaKimNamChung.grammarChecker.docx.Paragraph;
+import org.apache.poi.xwpf.usermodel.XWPFParagraph;
+
+public interface ParagraphApply {
+    public void paragraphParse(XWPFParagraph paragraph, Paragraph p);
+}


### PR DESCRIPTION
ParagraphApply를 인터페이스로 따로 빼내고 구현
편집거리를 계산하여 최대한 기존 서식을 유지해주고자 함
적용 우선순위 변경이 필요할 수 있음(현재 뒤에서부터 KEEP, CASCADE, DELETE, ADD 순서대로 우선 적용)