### PR TITLE
:pencil2: POST 요청이 2번 되는 오류 수정

### DIFF
--- a/src/main/java/choiKoDaKimNamChung/grammarChecker/service/docx/DocxParserImp.java
+++ b/src/main/java/choiKoDaKimNamChung/grammarChecker/service/docx/DocxParserImp.java
@@ -162,11 +162,8 @@ public class DocxParserImp implements DocxParser {
                 .retrieve()
                 .bodyToFlux(WordError.class);
 
-        response.subscribe(wordError -> {
-            result.getErrors().add(wordError);
-        });
-
-        response.blockLast();
+        List<WordError> errors = response.collectList().block();
+        result.getErrors().addAll(errors);
 
         return result;
     }


### PR DESCRIPTION
- 이슈 번호
#34 

- 개요
Spring 서버에서 webClient로 Django 서버를 호출할 때 2번 호출되는 문제를 해결하여 1번만 호출하도록 수정하였습니다.
