### PR TITLE
[add] hwp 미주, 각주, 머리글, 바닥글 parse메서드 작성

### DIFF
--- a/src/main/java/choiKoDaKimNamChung/grammarChecker/service/ScanService.java
+++ b/src/main/java/choiKoDaKimNamChung/grammarChecker/service/ScanService.java
@@ -32,7 +32,7 @@ public class ScanService {
             throw new RuntimeException(e);
         }
         Docx spellCheckResponseDTO = docxParser.docxParse(document, type);
-        System.out.println("spellCheckResponseDTO = " + spellCheckResponseDTO);
+//        System.out.println("spellCheckResponseDTO = " + spellCheckResponseDTO);
         return ResponseEntity.ok(spellCheckResponseDTO);
     }
 

--- a/src/main/java/choiKoDaKimNamChung/grammarChecker/service/docx/DocxParserImp.java
+++ b/src/main/java/choiKoDaKimNamChung/grammarChecker/service/docx/DocxParserImp.java
@@ -33,6 +33,7 @@ public class DocxParserImp implements DocxParser {
             }
             List<IBody> note = new ArrayList<>();
             docx.getFootNote().add(note);
+            System.out.println("((XWPFParagraph) footnote).getText() = " + ((XWPFParagraph) footnote.getBodyElements().get(0)).getText());
             asyncIBody(note, footnote.getBodyElements(), spellCheckerType);
         }
 

--- a/src/main/java/choiKoDaKimNamChung/grammarChecker/service/hwp/HwpApply.java
+++ b/src/main/java/choiKoDaKimNamChung/grammarChecker/service/hwp/HwpApply.java
@@ -4,6 +4,7 @@ import choiKoDaKimNamChung.grammarChecker.domain.hwp.*;
 import kr.dogfoot.hwplib.object.HWPFile;
 import kr.dogfoot.hwplib.object.bodytext.Section;
 import kr.dogfoot.hwplib.object.bodytext.control.Control;
+import kr.dogfoot.hwplib.object.bodytext.control.ControlFootnote;
 import kr.dogfoot.hwplib.object.bodytext.control.ControlTable;
 import kr.dogfoot.hwplib.object.bodytext.control.ControlType;
 import kr.dogfoot.hwplib.object.bodytext.control.table.Cell;
@@ -29,7 +30,36 @@ public class HwpApply {
                 controlApply(paragraph, iter.next());
             }
         }
+        applyHeaders(hwpfile, hwp.getHeader());
+        applyFooters(hwpfile, hwp.getFooter());
+        applyFootnotes(hwpfile, hwp.getFootNote());
+        applyEndnotes(hwpfile, hwp.getEndNote());
+
         return hwpfile;
+    }
+
+    public void applyFootnotes(HWPFile hwpfile, List<IBody> footnotes) {
+        for (Section section : hwpfile.getBodyText().getSectionList()) {
+            for (Paragraph paragraph : section.getParagraphs()) {
+                if (paragraph.getControlList() != null) {
+                    for (Control control : paragraph.getControlList()) {
+                        if (control.getType() == ControlType.Footnote) {
+                            ControlFootnote footnote = (ControlFootnote) control;
+                            applyParagraphs(footnote.getParagraphList().getParagraphs(), footnotes);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private void applyParagraphs(Paragraph[] paragraphs, List<IBody> bodies) {
+        Iterator<IBody> iter = bodies.iterator();
+        for (Paragraph paragraph : paragraphs) {
+            if (iter.hasNext()) {
+                controlApply(paragraph, iter.next());
+            }
+        }
     }
 
     public void controlApply(Paragraph paragraph, IBody iBody){


### PR DESCRIPTION
hwp 미주, 각주, 머리글, 바닥글 parse 메서드 구현하였습니다.

docx와 달리 한번에 각 요소를 뽑아내는 메서드가 제공되지 않아, 모든 본문을 순회하여 효율적으로 요소를 뽑아내기 위해
하나의 메서드에 작성했습니다.